### PR TITLE
ENH remove old MPI pinnings in favor of run exports

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) 2015-2021, conda-forge contributors
+Copyright (c) 2015-2022, conda-forge contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -192,6 +192,3 @@ Feedstock Maintainers
 * [@RobinD42](https://github.com/RobinD42/)
 * [@oskooi](https://github.com/oskooi/)
 
-
-<!-- dummy commit to enable rerendering -->
-

--- a/README.md
+++ b/README.md
@@ -192,3 +192,6 @@ Feedstock Maintainers
 * [@RobinD42](https://github.com/RobinD42/)
 * [@oskooi](https://github.com/oskooi/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,3 @@
 mpi:
   - nompi
   - mpich
-
-pin_run_as_build:
-  mpich: x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "h5utils" %}
 {% set version = "1.13.1" %}
 {% set sha256 = "c5a76f064d6daa3e65583dce2b61202510e67cf6590f076af9a8aa72511d7d65" %}
-{% set build = 1012 %}
+{% set build = 1013 %}
 
 # recipe-lint fails if mpi is undefined
 {% set mpi = mpi or "nompi" %}


### PR DESCRIPTION
We have switched MPI to use run exports and the old pin run as build keys produce the wrong exports. This PR removes them.